### PR TITLE
shell: allowing custom shell for non-posix env

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -29,6 +29,10 @@ inputs:
     description: 'target to build'
     type: 'string'
     default: ''
+  shell:
+    description: 'shell to use'
+    type: 'string'
+    default: 'bash'
 
 runs:
   using: 'composite'
@@ -36,7 +40,7 @@ runs:
     - name: 'Meson Prefetch'
       if: ${{ contains(fromJSON(inputs.actions), 'prefetch') }}
       working-directory: ${{ inputs.projectdir }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         meson subprojects download || true
         meson subprojects foreach python3 -m pip install -r requirements.txt || true
@@ -44,7 +48,7 @@ runs:
     - name: 'Meson Setup'
       if: ${{ contains(fromJSON(inputs.actions), 'setup') }}
       working-directory: ${{ inputs.projectdir }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         CROSS_FILES=
         for f in ${{ inputs.cross_files }}; do
@@ -55,34 +59,34 @@ runs:
     - name: 'Meson Compile'
       if: ${{ contains(fromJSON(inputs.actions), 'compile') }}
       working-directory: ${{ format('{0}/{1}', inputs.projectdir, inputs.builddir) }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         ninja ${{ inputs.targets }}
 
     - name: 'Meson Test'
       if: ${{ contains(fromJSON(inputs.actions), 'test') }}
       working-directory: ${{ format('{0}/{1}', inputs.projectdir, inputs.builddir) }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         ninja test
 
     - name: 'Meson Coverage Report'
       if: ${{ contains(fromJSON(inputs.actions), 'test') && inputs.coverage == 'true' }}
       working-directory: ${{ format('{0}/{1}', inputs.projectdir, inputs.builddir) }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         ninja coverage
 
     - name: 'Meson Install'
       if: ${{ contains(fromJSON(inputs.actions), 'install') }}
       working-directory: ${{ format('{0}/{1}', inputs.projectdir, inputs.builddir) }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         ninja install
 
     - name: 'Meson Dist'
       if: ${{ contains(fromJSON(inputs.actions), 'dist') }}
       working-directory: ${{ format('{0}/{1}', inputs.projectdir, inputs.builddir) }}
-      shell: bash
+      shell: ${{ input.shell }}
       run: |
         meson dist --no-tests --include-subprojects


### PR DESCRIPTION
default shell is bash but may be superseeded to msys2 for e.g.